### PR TITLE
Fix tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,7 @@ services:
       - JAEGER_HTTP_URL=http://jaeger:14268/api/traces
     depends_on:
       - jaeger
-    volumes:
-      - ./config/compose.toml:/app/config/config.toml
-    networks:
-      - web5_network
+      - redis
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
@@ -26,8 +23,8 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     # This allows for data to not be persisted on new runs
     command: [sh, -c, "rm -f /data/dump.rdb && redis-server --save ''"]
-    networks:
-      - web5_network
+    ports:
+      - "6379:6379"
   dwn-relay-web:
     build:
       context: ./
@@ -36,9 +33,4 @@ services:
       - "9000:9000"
     environment:
       - API_URL=http://172.17.0.1:8080
-    networks:
-      - web5_network
 
-
-networks:
-  web5_network:

--- a/ssi/Dockerfile
+++ b/ssi/Dockerfile
@@ -8,7 +8,6 @@ RUN git clone https://github.com/TBD54566975/ssi-service.git
 
 WORKDIR /app/ssi-service
 
-RUN ls -alt
 RUN go mod download
 RUN go build -tags jwx_es256k -o /docker-ssi-service ./cmd/ssiservice
 RUN rm config/config.toml

--- a/ssi/Dockerfile
+++ b/ssi/Dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:latest
+FROM golang:1.20.2-alpine
 
-RUN apt-get -y update
-RUN apt-get -y install git
-RUN apt-get -y install golang-go
+RUN apk add --no-cache git
 
 WORKDIR /app
 
@@ -13,9 +11,9 @@ WORKDIR /app/ssi-service
 RUN ls -alt
 RUN go mod download
 RUN go build -tags jwx_es256k -o /docker-ssi-service ./cmd/ssiservice
+RUN rm config/config.toml
+RUN cp config/compose.toml config/config.toml
 
 EXPOSE 3000
 
 CMD [ "/docker-ssi-service" ]
-
-


### PR DESCRIPTION
This fixes the tests by:
* Specifying ports.
* Removing the networks so we use defaults.
* Upgrading to golang 1.20.2
* Using the compose.toml file for configuration of ssi-service