### PR TITLE
some extra option for slightly easier test development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN CGO_ENABLED=0 go build ./cmd/web5-components-tests
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /go/web5-components-test/web5-components-tests /web5-components-tests
-CMD [ "/web5-components-tests", "-test-only" ]
+CMD [ "/web5-components-tests", "-no-start" ]

--- a/cmd/web5-components-tests/main.go
+++ b/cmd/web5-components-tests/main.go
@@ -10,20 +10,27 @@ import (
 )
 
 var (
-	testOnly = flag.Bool("test-only", false, "when set, the server is not built and is expected to be already running")
-	server   = flag.String("server", "http://localhost:8080", "url of the server to connect to")
+	nostart = flag.Bool("no-start", false, "when set, the server is not built and is expected to be already running")
+	nostop  = flag.Bool("no-stop", false, "when set, the server is not asked to shut down")
+	server  = flag.String("server", "http://localhost:8080", "url of the server to connect to")
 )
 
 func main() {
 	flag.Parse()
 
+	dir, _ := os.Getwd()
+	if len(flag.Args()) > 0 {
+		dir = flag.Arg(0)
+	}
+
 	logger := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
 	slog.SetDefault(slog.New(logger))
 
-	if !*testOnly {
+	if !*nostart {
 		cmd := exec.Command("docker", "build", "-t", "web5-component:latest", "-f", ".web5-component/test.Dockerfile", ".")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Dir = dir
 		if err := cmd.Run(); err != nil {
 			slog.Error("error building server", "error", err)
 			os.Exit(1)
@@ -32,20 +39,23 @@ func main() {
 		cmd = exec.Command("docker", "run", "-p", "8080:8080", "--rm", "web5-component:latest")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Dir = dir
 		if err := cmd.Start(); err != nil {
 			slog.Error("error running server", "error", err)
 			os.Exit(1)
 		}
 
-		defer func() {
-			slog.Debug("shutting down server")
-			if err := cmd.Process.Signal(os.Kill); err != nil {
-				panic(err)
-			}
-			if err := cmd.Wait(); err != nil {
-				panic(err)
-			}
-		}()
+		if !*nostop {
+			defer func() {
+				slog.Debug("shutting down server")
+				if err := cmd.Process.Signal(os.Kill); err != nil {
+					panic(err)
+				}
+				if err := cmd.Wait(); err != nil {
+					panic(err)
+				}
+			}()
+		}
 	}
 
 	tests.RunTests(*server)


### PR DESCRIPTION
This adds a few extra cli options:

* `-no-stop` - dont shut down the test server, presumably helpful while writing tests.
* `-no-start` - renamed `-test-only` to be more clear
* first arg after flags is treated as the path to the test directory, if set

for example, to build local tests from a different directory:

```
go run ./cmd/web5-components-tests ../web5-js
```